### PR TITLE
fix: update extension to use object for new preprocess API

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (options) {
     extension = _.isEmpty(opts.extension) ? getExtension(context.src) : opts.extension;
 
     contents = file.contents.toString('utf8');
-    contents = pp.preprocess(contents, context, extension);
+    contents = pp.preprocess(contents, context, {type: extension});
     file.contents = new Buffer(contents);
 
     callback(null, file);


### PR DESCRIPTION
Apparently `#preprocess` expects an option object as 3rd param, see https://github.com/jsoverson/preprocess#api. Please take a look.