### PR TITLE
Context env fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ var path  = require('path');
 
 module.exports = function (options) {
   var opts    = _.merge({}, options);
-  var context = _.merge({}, process.env, opts.context);
+  var context = _.merge(
+    {}, process.env, options.context, customMergerFor(options)
+  );
 
   function ppStream(file, callback) {
     var contents, extension;
@@ -33,4 +35,15 @@ module.exports = function (options) {
 function getExtension(filename) {
   var ext = path.extname(filename||'').split('.');
   return ext[ext.length - 1];
+}
+
+// Allows using 'undefined' values as part of the explicit context passed
+// to options, hence allowing override of environment variables, but more
+// importantly, re-enabling the use of @ifdef and @ifndef in preprocess
+function customMergerFor(options) {
+  return function(objVal, sourceVal, key, object, source) {
+    if (source === options.context && sourceVal === undefined) {
+      object[key] = sourceVal;
+    }
+  };
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ var path  = require('path');
 module.exports = function (options) {
   var opts    = _.merge({}, options);
   var context = _.merge(
-    {}, process.env, options.context, customMergerFor(options)
+    {},
+    process.env,
+    options ? options.context : {},
+    customMergerFor(options)
   );
 
   function ppStream(file, callback) {
@@ -42,7 +45,11 @@ function getExtension(filename) {
 // importantly, re-enabling the use of @ifdef and @ifndef in preprocess
 function customMergerFor(options) {
   return function(objVal, sourceVal, key, object, source) {
-    if (source === options.context && sourceVal === undefined) {
+    var shouldAssign = typeof(options) !== 'undefined' &&
+      source === options.context &&
+      sourceVal === undefined;
+
+    if (shouldAssign) {
       object[key] = sourceVal;
     }
   };


### PR DESCRIPTION
This allows explicitly passed variables in `context` to override what's on `process.env` and effectively restores the ability to pass an `undefined` variable to leverage preprocess' `@ifdef`/`@ifndef`. This should also allow an override of an environment variable by us, which was possible with the default lodash's merge, except you weren't able to unset it. I'm not familiar with this project, just happen to be using it, perhaps you might be able to discuss why this plugin's approach it's to merge with all env vars while preprocess seems to be either custom or env vs custom and env as in this plugin?

@jas, @ioloie thoughts?