### PR TITLE
gulp-data-acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Default: `{}`
 
 Context for directives used in your preprocessed files. The default context consists of the current user environment variables. Custom context is merged with `process.env`.
 
+If the `file` object contains property `data` (created by `gulp-data` plugin for example), its contents are merged to a context.
+
 #### options.includeBase
 Type: `String`
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = function (options) {
     if (file.isNull()) return callback(null, file); // pass along
     if (file.isStream()) return callback(new Error("gulp-preprocess: Streaming not supported"));
 
+    // accept context passed from `gulp-data` plugin
+    context = _.merge(context, file.data);
+
     context.src = file.path;
     context.srcDir = opts.includeBase || path.dirname(file.path);
     context.NODE_ENV = context.NODE_ENV || 'development';


### PR DESCRIPTION
Accept context data passed from `gulp-data` plugin (`file.data`).

For example, piping *yaml front matter* (`gulp-front-matter`) through `gulp-data` to `gulp-preprocess` implicitly (*coffeescript* fragment):
```coffeescript
...
.pipe frontMatter()
.pipe data (file) ->
  file.frontMatter
.pipe preprocess()
...
```